### PR TITLE
Fixed overflow due to logo not being hidden in light mode

### DIFF
--- a/src/sections/Landing.js
+++ b/src/sections/Landing.js
@@ -57,8 +57,8 @@ const Landing = () => {
                                 Built using
                             </h6>
                             <div className="flex items-center py-6">
-                                <img className="w-[200px] min-h-[50px] show dark:hidden" src={vulkan} alt="lol" />
-                                <img className="w-[200px] min-h-[50px] show dark:show" src={vulkan_white} alt="lol" />
+                                <img className="w-[200px] min-h-[50px] show dark:hidden" src={vulkan} alt="Vulcan Logo" />
+                                <img className="w-[200px] min-h-[50px] hidden dark:block" src={vulkan_white} alt="Vulcan Logo" />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
I noticed the website overflows whenever light mode is toggled on:

![skyline-overflow](https://user-images.githubusercontent.com/4678264/171988732-5f704dd1-b8e2-4139-927e-d5191ecb5f8b.gif)

I've set it to be hidden by default and the image set to `display: block` when dark mode is toggled on.