### PR TITLE
Fix: BuildCard titles cutting off in shorter titles

### DIFF
--- a/src/components/BuildCard.js
+++ b/src/components/BuildCard.js
@@ -65,7 +65,7 @@ const Markdown = ({ string }) => {
 
 const BuildCard = ({ createdAt, message, download_url, github_url, branch, hash, number }) => {
     const titleEnd = message.indexOf("\n", 1);
-    const title = message.slice(0, titleEnd);
+    const title = titleEnd !== -1 ? message.slice(0, titleEnd) : message;
     var description = message.slice(titleEnd + 1);
     while (description.charAt(0) === "\n") description = description.slice(1);
 


### PR DESCRIPTION
## Fixes
- BuildCard titles cutting of at the end of the title which are short and do not contain `\n` in the commit messages the texts are pulled from
![image](https://user-images.githubusercontent.com/4678264/192326343-a118c4b6-e80e-466a-bc80-74baf4fde9e2.png)
![image](https://user-images.githubusercontent.com/4678264/192326496-666a1d37-8383-4bf3-bb51-1e464291eb0c.png)
